### PR TITLE
feat(flake): rework theming

### DIFF
--- a/modules/home/desktop/options.nix
+++ b/modules/home/desktop/options.nix
@@ -28,6 +28,47 @@ in {
         };
       };
 
+    # * https://github.com/catppuccin/nix/issues/96
+    colorScheme = mkOption {
+      default = inputs.nix-colors.colorSchemes.catppuccin-mocha;
+
+      type = types.attrs;
+      description = ''
+        Your nix-colors scheme
+      '';
+    };
+
+    gtk = {
+      theme.package = mkOption {
+        description = "The nixpkg for the gtk-theme";
+        type = types.package;
+        default = pkgs.catppuccin-gtk.override {
+          accents = ["lavender"];
+          variant = "mocha";
+        };
+      };
+      iconTheme.package = mkOption {
+        description = "The nixpkg for the gtk-icon theme";
+        type = types.package;
+        default = pkgs.catppuccin-papirus-folders;
+      };
+    };
+    qt = {
+      theme.package = mkOption {
+        description = "The nixpkg for the qt-theme";
+        type = types.package;
+        default = pkgs.catppuccin-kvantum.override {
+          accent = "Lavender";
+          variant = "Mocha";
+        };
+      };
+      name = mkOption {
+        description = "The name of the package which it appears under";
+        type = types.string;
+        default = "kvantum";
+      };
+    };
+
     flatpak = {
       enable = mkEnableOption ''
         installing Flatpak applications with Nix from Home Manager


### PR DESCRIPTION
I think adding support for let's say `nix-colors` is bit out of line, since some stuff as for example *[gtk themes](https://github.com/jh-devv/luminara/blob/536222d8a6a8afe87c1d357828a9d615da5f53de/modules/home/desktop/hyprwm/gtk.nix)* don't really sit with that.

I could just add `nix-colors` and add their own stuff for them (like currently in the patch files) but yea...

I am also waiting for https://github.com/catppuccin/nix/issues/96 (and hereby https://github.com/catppuccin/nix/pull/129) to progress since `catppuccin-nix` handles stuff like *gtk themes* that `nix-colors` does not. It would also be easier since I could just support all <ins>Catppuccin themes</ins>, but just not all <ins>themes</ins>?